### PR TITLE
Add User Agent configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/spider"
 maintenance = { status = "as-is" }
 
 [dependencies]
-reqwest = "0.9.22"
-scraper = "0.11.0"
+reqwest = { version = "0.11", features = ["blocking"] }
+scraper = "0.12"
 robotparser = "0.10"
-url = "2.2.0"
+url = "2.2"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -14,6 +14,8 @@ pub struct Configuration {
     pub verbose: bool,
     /// List of page to not crawl
     pub blacklist_url: Vec<String>,
+    /// User-Agent
+    pub user_agent: &'static str,
 }
 
 impl Configuration {
@@ -22,6 +24,7 @@ impl Configuration {
             respect_robots_txt: false,
             verbose: false,
             blacklist_url: Vec::new(),
+            user_agent: "spider/1.1.2",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 extern crate reqwest;
-extern crate scraper;
 extern crate robotparser;
+extern crate scraper;
 extern crate url;
 
-/// A website to crawl
-pub mod website;
-/// A page scraped
-pub mod page;
 /// Configuration structure for `Website`
 pub mod configuration;
+/// A page scraped
+pub mod page;
+/// A website to crawl
+pub mod website;


### PR DESCRIPTION
This adds the ability to set one's own user agent or simply fall back to library's default UA; spider.

PS: This PR contains automated formatting changes.