### PR TITLE
Drop URL fragment from absolute path

### DIFF
--- a/src/page.rs
+++ b/src/page.rs
@@ -88,7 +88,9 @@ impl Page {
 
     fn abs_path(&self, href: &str) -> Result<Url, ParseError> {
         let base = Url::parse(&self.url.to_string()).expect("Invalid page URL");
-        let joined = base.join(href)?;
+        let mut joined = base.join(href)?;
+        
+        joined.set_fragment(None);
 
         Ok(joined)
     }

--- a/src/page.rs
+++ b/src/page.rs
@@ -73,7 +73,7 @@ impl Page {
         for anchor in anchors {
             match anchor.value().attr("href") {
                 Some(href) => {
-                    let abs_path = self.abs_path(href).unwrap();
+                    let abs_path = self.abs_path(href);
 
                     if abs_path.as_str().starts_with(domain) {
                         urls.push(format!("{}", abs_path));
@@ -86,7 +86,7 @@ impl Page {
         urls
     }
 
-    fn abs_path(&self, href: &str) -> Result<Url, ParseError> {
+    fn abs_path(&self, href: &str) -> Url {
         let base = Url::parse(&self.url.to_string()).expect("Invalid page URL");
         let mut joined = base.join(href).unwrap_or(base);
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -88,11 +88,11 @@ impl Page {
 
     fn abs_path(&self, href: &str) -> Result<Url, ParseError> {
         let base = Url::parse(&self.url.to_string()).expect("Invalid page URL");
-        let mut joined = base.join(href)?;
-        
+        let mut joined = base.join(href).unwrap_or(base);
+
         joined.set_fragment(None);
 
-        Ok(joined)
+        joined
     }
 }
 


### PR DESCRIPTION
Drop URL fragment (hash) from absolute path of extracted links.

If left, spider might crawl the same page multiple times since fragments (hashes) makes it look like a different web page.