### PR TITLE
feat(concurrency): dynamic concurrent cpu defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,10 +1043,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
+ "hermit-abi",
  "libc",
 ]
 
@@ -1794,6 +1804,7 @@ dependencies = [
 name = "spider"
 version = "1.3.1"
 dependencies = [
+ "num_cpus",
  "rayon",
  "reqwest 0.11.0",
  "robotparser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "num_cpus",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>"]
 description = "Multithreaded Web spider crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -19,6 +19,7 @@ scraper = "0.12"
 robotparser = "0.10"
 url = "2.2"
 rayon = "1.1"
+num_cpus = "1.13.0"
 
 [[example]]
 name = "example"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ cargo run --example example
 
 ## TODO
 
-- [x] multi-threaded system
 - [x] respect _robot.txt_ file
 - [x] add configuration object for polite delay, etc..
 - [x] add polite delay

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ cargo run --example example
 
 ## TODO
 
+- [x] multi-threaded system
 - [x] respect _robot.txt_ file
 - [x] add configuration object for polite delay, etc..
 - [x] add polite delay

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add this dependency to your _Cargo.toml_ file.
 
 ```toml
 [dependencies]
-spider = "1.3.1"
+spider = "1.3.2"
 ```
 
 Then you'll be able to use library. Here is a simple example:
@@ -53,7 +53,7 @@ website.configuration.blacklist_url.push("https://choosealicense.com/licenses/".
 website.configuration.respect_robots_txt = true;
 website.configuration.verbose = true; // Defaults to false
 website.configuration.delay = 2000; // Defaults to 250 ms
-website.configuration.concurrency = 10; // Defaults to 4
+website.configuration.concurrency = 10; // Defaults to number of cpus available
 website.configuration.user_agent = "myapp/version"; // Defaults to spider/x.y.z, where x.y.z is the library version
 website.on_link_find_callback = |s| { println!("link target: {}", s); s }; // Callback to run on each link find
 

--- a/example.rs
+++ b/example.rs
@@ -8,7 +8,7 @@ fn main() {
   website.configuration.respect_robots_txt = true;
   website.configuration.verbose = true; // Defaults to false
   website.configuration.delay = 2000; // Defaults to 250 ms
-  website.configuration.concurrency = 10; // Defaults to 4
+  website.configuration.concurrency = 10; // Defaults to number of cpus available
   website.configuration.user_agent = "myapp/version"; // Defaults to spider/x.y.z, where x.y.z is the library version
   website.crawl();
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -27,9 +27,9 @@ pub struct Configuration {
 impl Configuration {
     pub fn new() -> Self {
         Self {
-            user_agent: "spider/1.2.1",
+            user_agent: "spider/1.3.2",
             delay: 250,
-            concurrency: num_cpus::get() | 4,
+            concurrency: num_cpus::get(),
             ..Default::default()
         }
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -29,7 +29,7 @@ impl Configuration {
         Self {
             user_agent: "spider/1.3.2",
             delay: 250,
-            concurrency: num_cpus::get(),
+            concurrency: num_cpus::get() * 4,
             ..Default::default()
         }
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,3 +1,5 @@
+use num_cpus;
+
 /// Structure to configure `Website` crawler
 /// <pre>
 /// let mut website: Website = Website::new("https://choosealicense.com");
@@ -27,7 +29,7 @@ impl Configuration {
         Self {
             user_agent: "spider/1.2.1",
             delay: 250,
-            concurrency: 4,
+            concurrency: num_cpus::get() | 4,
             ..Default::default()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate reqwest;
 extern crate robotparser;
 extern crate scraper;
 extern crate url;
+extern crate num_cpus;
 
 /// Configuration structure for `Website`
 pub mod configuration;

--- a/src/website.rs
+++ b/src/website.rs
@@ -73,6 +73,7 @@ impl<'a> Website<'a> {
         while !self.links.is_empty() {
             let mut new_links: HashSet<String> = HashSet::new();
             let (tx, rx) = sync::mpsc::channel();
+            let on_link_find_callback = self.on_link_find_callback;
 
             self.links
                 .iter()
@@ -87,6 +88,7 @@ impl<'a> Website<'a> {
                     let tx = tx.clone();
 
                     pool.spawn(move || {
+                        on_link_find_callback(thread_link.clone());
                         tx.send(Page::new(&thread_link, user_agent)).unwrap();
                         thread::sleep(delay);
                     });
@@ -95,8 +97,6 @@ impl<'a> Website<'a> {
             drop(tx);
 
             rx.into_iter().for_each(|page| {
-                (self.on_link_find_callback)(page.get_url());
-
                 if self.configuration.verbose {
                     println!("- parse {}", page.get_url());
                 }

--- a/src/website.rs
+++ b/src/website.rs
@@ -88,8 +88,8 @@ impl<'a> Website<'a> {
                     let tx = tx.clone();
 
                     pool.spawn(move || {
-                        on_link_find_callback(thread_link.clone());
-                        tx.send(Page::new(&thread_link, user_agent)).unwrap();
+                        let link_result = on_link_find_callback(thread_link);
+                        tx.send(Page::new(&link_result, user_agent)).unwrap();
                         thread::sleep(delay);
                     });
                 });


### PR DESCRIPTION
1. dynamically check cpus to use for concurrency as default: increase parallelism default performance 
1. move link callback to thread (performance boost)

- performance
initial tests ran at about 8s
afterwards test ran at about 3s