### PR TITLE
feat(cli): add cli ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cargo run --example example
 ## Cli
 
 The following can also be ran via command line to run the crawler.
-All website options are available except `website.configuration.user_agent` and `website.on_link_find_callback`.
+All website options are available except `website.on_link_find_callback`.
 
 ```sh
 cargo run -- --domain https://choosealicense.com --verbose true --delay 2000

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ You can get a working example at [`example.rs`](./example.rs) and run it with
 cargo run --example example
 ```
 
-## TODO
+## Cli
 
-- [x] multi-threaded system
-- [x] respect _robot.txt_ file
-- [x] add configuration object for polite delay, etc..
-- [x] add polite delay
-- [ ] parse command line arguments
+The following can also be ran via command line to run the crawler.
+All website options are available except `website.configuration.user_agent` and `website.on_link_find_callback`.
+
+```sh
+cargo run -- --domain https://choosealicense.com --verbose true --delay 2000
+```
 
 ## Contribute
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,56 @@
+extern crate spider;
+
+use spider::website::Website;
+use std::collections::HashMap;
+
+fn parse_args(mut args: impl Iterator<Item = String>) -> HashMap<String, String> {
+    let mut flags = HashMap::new();
+    
+    while let Some(arg) = args.next() {
+        if let Some(flag) = arg.strip_prefix("-") {
+            if let Some(option) = flag.strip_prefix("-") {
+                flags.insert(option.into(), args.next().unwrap_or_default());
+            } else {
+                for fchar in flag.chars() {
+                    flags.insert(fchar.into(), String::from("1"));
+                }
+            }
+        }
+    }
+
+    flags
+}
+
+fn main() {
+    let options = parse_args(std::env::args());
+    let mut website: Website = Website::new(&options["domain"]);
+
+    if options.contains_key("respect_robots_txt") {
+        website.configuration.respect_robots_txt = &options["respect_robots_txt"] == "true";
+    }
+    if options.contains_key("verbose") {
+        website.configuration.verbose = &options["verbose"] == "true";
+    }
+    if options.contains_key("delay") {
+        let delay = &options["delay"];
+        website.configuration.delay = delay.parse::<u64>().unwrap();
+    }
+    if options.contains_key("concurrency") {
+        let concurrency = &options["concurrency"];
+        website.configuration.concurrency = concurrency.parse::<usize>().unwrap();
+    }
+    if options.contains_key("blacklist_url") {
+        website.configuration.blacklist_url.push(options["blacklist_url"].to_string());
+    }
+
+    // TODO: add user_agent ability as static
+    // if options.contains_key("user_agent") {
+    //     website.configuration.user_agent = options["user_agent"].to_string();
+    // }
+    // TODO: add on_link_find_callback eval function
+    // if options.contains_key("on_link_find_callback") {
+    //     website.on_link_find_callback = options["on_link_find_callback"];
+    // }
+
+    website.crawl();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,27 +26,25 @@ fn main() {
     let mut website: Website = Website::new(&options["domain"]);
 
     if options.contains_key("respect_robots_txt") {
-        website.configuration.respect_robots_txt = &options["respect_robots_txt"] == "true";
+        website.configuration.respect_robots_txt = options["respect_robots_txt"] == "true";
     }
     if options.contains_key("verbose") {
-        website.configuration.verbose = &options["verbose"] == "true";
+        website.configuration.verbose = options["verbose"] == "true";
     }
     if options.contains_key("delay") {
-        let delay = &options["delay"];
-        website.configuration.delay = delay.parse::<u64>().unwrap();
+        website.configuration.delay = options["delay"].parse::<u64>().unwrap();
     }
     if options.contains_key("concurrency") {
-        let concurrency = &options["concurrency"];
-        website.configuration.concurrency = concurrency.parse::<usize>().unwrap();
+        website.configuration.concurrency = options["concurrency"].parse::<usize>().unwrap();
     }
     if options.contains_key("blacklist_url") {
         website.configuration.blacklist_url.push(options["blacklist_url"].to_string());
     }
 
-    // TODO: add user_agent ability as static
-    // if options.contains_key("user_agent") {
-    //     website.configuration.user_agent = options["user_agent"].to_string();
-    // }
+    if options.contains_key("user_agent") {
+        website.configuration.user_agent = Box::leak(options["user_agent"].to_owned().into_boxed_str());
+    }
+
     // TODO: add on_link_find_callback eval function
     // if options.contains_key("on_link_find_callback") {
     //     website.on_link_find_callback = options["on_link_find_callback"];


### PR DESCRIPTION
1. add ability to run crawler via cli

-- all options available except `user_agent` and `on_link_find_callback`

example
cargo run -- --domain https://choosealicense.com --verbose true --delay 2000

![Screen Shot 2022-02-21 at 8 43 59 AM](https://user-images.githubusercontent.com/8095978/154966768-f33910e9-d7bc-4508-8d5c-db821e8b5420.png)
