### PR TITLE
feat(async): add async page body gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - chore(bin): fix bin executable [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)
 - feat(cli): add cli separation binary [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)
 - feat(robots): add robots crawl delay respect and ua assign [#24](https://github.com/madeindjs/spider/pull/24)
+- feat(async): add async page body gathering
 
 ## v1.4.0
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -21,4 +21,4 @@ robotparser-fork = "0.10.5"
 url = "2.2"
 rayon = "1.1"
 num_cpus = "1.13.0"
-tokio = { version = "^1.17.0", features = ["full"] }
+tokio = { version = "^1.17.0", features = ["rt-multi-thread", "net", "macros"] }

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -9,14 +9,16 @@ keywords = ["crawler", "spider"]
 categories = ["web-programming"]
 license = "MIT"
 documentation = "https://docs.rs/spider"
+edition = "2018"
 
 [badges]
 maintenance = { status = "as-is" }
 
 [dependencies]
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11" }
 scraper = "0.12"
 robotparser-fork = "0.10.5"
 url = "2.2"
 rayon = "1.1"
 num_cpus = "1.13.0"
+tokio = { version = "^1.17.0", features = ["full"] }

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -4,6 +4,7 @@ extern crate robotparser_fork;
 extern crate scraper;
 extern crate url;
 extern crate num_cpus;
+extern crate tokio;
 
 /// Configuration structure for `Website`
 pub mod configuration;

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -1,5 +1,5 @@
-use configuration::Configuration;
-use page::Page;
+use crate::configuration::Configuration;
+use crate::page::Page;
 use rayon::ThreadPoolBuilder;
 use robotparser_fork::RobotFileParser;
 


### PR DESCRIPTION
1. add peer matching tokio to crate deps.
  - rayon uses tokio in a dep but, the package does not re-export the runtime for usage outside, requires us to install ontop. This does not duplicate the package installation.
  
2. move html content to async call
3. update rust edition for async

-- screenshot of tokio being used in main prior to PR.

robotparser package has tokio as a dev dep, can view it here [robotparser](https://github.com/messense/robotparser-rs/blob/master/Cargo.toml).



![Screen Shot 2022-03-29 at 2 02 54 PM](https://user-images.githubusercontent.com/8095978/160676580-d19a21d0-f16b-4a0d-a5c6-3d989bb122fa.png)

https://github.com/madeindjs/spider/issues/21 