### PR TITLE
feat(robots): add robots crawl delay respect and ua assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - chore(bin): fix bin executable [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)
 - feat(cli): add cli separation binary [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)
+- feat(robots): add robots crawl delay respect and ua assign [#24](https://github.com/madeindjs/spider/pull/24)
 
 ## v1.4.0
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -10,6 +10,7 @@ fn main() {
   website.configuration.delay = 2000; // Defaults to 250 ms
   website.configuration.concurrency = 10; // Defaults to number of cpus available
   website.configuration.user_agent = "myapp/version"; // Defaults to spider/x.y.z, where x.y.z is the library version
+  website.configure_robots_parser(); // Defaults to extracting robot configuration at 'website.crawl' call if respect_robots_txt=true
   website.crawl();
 }
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "as-is" }
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }
 scraper = "0.12"
-robotparser = "0.10"
+robotparser-fork = "0.10.5"
 url = "2.2"
 rayon = "1.1"
 num_cpus = "1.13.0"

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate rayon;
 extern crate reqwest;
-extern crate robotparser;
+extern crate robotparser_fork;
 extern crate scraper;
 extern crate url;
 extern crate num_cpus;


### PR DESCRIPTION
1. fix robotsparser getting crawl_delay
1. fix robotsparser assign user agent for request to extract the `robots.txt` file. Different from configuration.user_agent used to extract the agent entry in the file.
1. fix reading robots.txt action unless `self.configuration.respect_robots_txt` is enabled.

-- notes
The robotsparser repo looks a little dead and the library did not publish version 0.11.0 on the docs which has some drastic differences on how we handle the parsing. Made a test fork here https://github.com/j-mendez/robotparser-rs/commits/master. The fork starts off at 10.2 the latest version and patches up the issue on respect the entry casing for `Crawl-delay` amongst other properties and additional features like req UA setting. 