### PR TITLE
perf(latency): add connection re-use across request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat(cli): add cli separation binary [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)
 - feat(robots): add robots crawl delay respect and ua assign [#24](https://github.com/madeindjs/spider/pull/24)
 - feat(async): add async page body gathering
+- perf(latency): add connection re-use across request [#25](https://github.com/madeindjs/spider/pull/25)
 
 ## v1.4.0
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2018"
 maintenance = { status = "as-is" }
 
 [dependencies]
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11.10" }
 scraper = "0.12"
 robotparser-fork = "0.10.5"
 url = "2.2"
-rayon = "1.1"
+rayon = "1.5"
 num_cpus = "1.13.0"
 tokio = { version = "^1.17.0", features = ["rt-multi-thread", "net", "macros"] }

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -12,3 +12,5 @@ pub mod configuration;
 pub mod page;
 /// A website to crawl
 pub mod website;
+/// Application utils
+pub mod utils;

--- a/spider/src/utils.rs
+++ b/spider/src/utils.rs
@@ -1,0 +1,13 @@
+pub use reqwest::{Client, Error};
+
+#[tokio::main]
+pub async fn fetch_page_html(url: &str, client: &Client) -> Result<String, Error> {
+	let body = client
+		.get(url)
+		.send()
+		.await?
+        .text()
+        .await?;
+
+    Ok(body)
+}


### PR DESCRIPTION
1. re-use connections across request (major latency improvement)
1. remove auto drop values (fix easy re-crawling without needing to re-instantiate )
1. add invalid crawl test case to make sure program does not exit
1. upgrade rayon latest
