### PR TITLE
chore(links): fix parsing valid website pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- chore(links): fix parsing valid website pages [#30](https://github.com/madeindjs/spider/pull/30)
+
 ## v1.5.0
 
 - chore(bin): fix bin executable [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -39,20 +39,13 @@ impl Page {
     /// Find all href links and return them
     pub fn links(&self, domain: &str) -> Vec<String> {
         let mut urls: Vec<String> = Vec::new();
-        let selector = Selector::parse("a").unwrap();
-
+        let selector = Selector::parse(&format!(r#" a[href^="{}"] a[href$=".html"], a:not([href*="."]) "#, domain)).unwrap();
         let html = self.get_html();
-        let anchors = html
-            .select(&selector)
-            .filter(|a| a.value().attrs().any(|attr| attr.0 == "href"));
+        let anchors = html.select(&selector);
 
         for anchor in anchors {
             if let Some(href) = anchor.value().attr("href") {
-                let abs_path = self.abs_path(href);
-
-                if abs_path.as_str().starts_with(domain) {
-                    urls.push(abs_path.to_string());
-                }
+                urls.push(self.abs_path(href).to_string());
             }
         }
 


### PR DESCRIPTION
1. fix valid selecting of page anchors.
2. drastic performance boost on getting valid links for domain.

---------------------------------------
45s shaved off the test runs.

Prior 
test finish around 2.89s
![Screen Shot 2022-04-14 at 7 36 44 PM](https://user-images.githubusercontent.com/8095978/163493553-ba652377-e41f-4a42-a410-51ebcf095a3b.png)

After 
test finish around 2.4s
![Screen Shot 2022-04-14 at 7 37 33 PM](https://user-images.githubusercontent.com/8095978/163493607-baa2d9dc-3efb-4c8d-8d98-49fe8930a5be.png)

Relates to https://github.com/madeindjs/spider/pull/29.