### PR TITLE
feat(regex): add optional regex black listing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(regex): add optional regex black listing
+
 ## v1.5.0
 
 - chore(bin): fix bin executable [#17](https://github.com/madeindjs/spider/pull/17/commits/b41e25fc507c6cd3ef251d2e25c97b936865e1a9)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.5.0"
+version = "1.5.3"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/spider"
 maintenance = { status = "as-is" }
 
 [dependencies.spider]
-version = "1.5.0"
+version = "1.5.3"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -22,3 +22,7 @@ url = "2.2"
 rayon = "1.5"
 num_cpus = "1.13.0"
 tokio = { version = "^1.17.0", features = ["rt-multi-thread", "net", "macros"] }
+regex = { version = "^1.5.0", optional = true }
+
+[features]
+regex = ["dep:regex"]

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"

--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -15,7 +15,7 @@ pub struct Configuration {
     pub respect_robots_txt: bool,
     /// Print page visited on standart output
     pub verbose: bool,
-    /// List of page to not crawl
+    /// List of pages to not crawl [optional: regex pattern matching]
     pub blacklist_url: Vec<String>,
     /// User-Agent
     pub user_agent: &'static str,

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -1,16 +1,40 @@
+extern crate num_cpus;
 extern crate rayon;
 extern crate reqwest;
 extern crate robotparser_fork;
 extern crate scraper;
-extern crate url;
-extern crate num_cpus;
 extern crate tokio;
+extern crate url;
 
 /// Configuration structure for `Website`
 pub mod configuration;
 /// A page scraped
 pub mod page;
-/// A website to crawl
-pub mod website;
 /// Application utils
 pub mod utils;
+/// A website to crawl
+pub mod website;
+
+#[cfg(feature = "regex")]
+mod black_list {
+    use regex::Regex;
+    /// check if link exist in blacklists with regex
+    pub fn contains(blacklist_url: &Vec<String>, link: &String) -> bool {
+        for pattern in blacklist_url {
+            let re = Regex::new(pattern).unwrap();
+            if re.is_match(link) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+#[cfg(not(feature = "regex"))]
+mod black_list {
+    /// check if link exist in blacklists
+    pub fn contains(blacklist_url: &Vec<String>, link: &String) -> bool {
+        blacklist_url.contains(&link)
+    }
+}

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -226,6 +226,18 @@ fn not_crawl_blacklist() {
 }
 
 #[test]
+#[cfg(feature = "regex")]
+fn not_crawl_blacklist_regex() {
+    let mut website: Website = Website::new("https://choosealicense.com");
+    website
+        .configuration
+        .blacklist_url
+        .push("/choosealicense.com/".to_string());
+    website.crawl();
+    assert_eq!(website.links_visited.len(), 0);
+}
+
+#[test]
 fn test_respect_robots_txt() {
     let mut website: Website = Website::new("https://stackoverflow.com");
     website.configuration.respect_robots_txt = true;

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"


### PR DESCRIPTION
1. add regex black list option

-- notes
atm `in_list` uses references. Might make sense to add as trait.

https://github.com/madeindjs/spider/issues/32