### PR TITLE
perf(crawl): improve crawl link exclusion

### DIFF
--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -9,7 +9,7 @@ use std::env;
 /// website.configuration.verbose = true;
 /// localhost.crawl();
 /// </pre>
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct Configuration {
     /// Respect robots.txt file and not scrape not allowed files (not implemented)
     pub respect_robots_txt: bool,

--- a/spider/src/utils.rs
+++ b/spider/src/utils.rs
@@ -1,4 +1,4 @@
-pub use reqwest::{Client, Error};
+pub use crate::reqwest::{Client, Error};
 
 #[tokio::main]
 pub async fn fetch_page_html(url: &str, client: &Client) -> Result<String, Error> {


### PR DESCRIPTION
1. improve crawl performance by skipping O(N) initial filter and need of additional copy from filter. ( few ms shaved on small pages website, more impactful on large crawls ).