### PR TITLE
perf(client): fix blocking and async mixture

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Benches
 on:
   push:
     branches: [master]
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_LOG: "off"
 
 jobs:
   build:
@@ -23,7 +24,16 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose --all-features
+      - name: Install Benchmark Dependencies
+        run: |
+          # install node-crawler
+          npm install -g crawler
+          # install go and deps
+          go mod init example.com/spider
+          go get github.com/gocolly/colly/v2
+          cat go.mod
+          go mod tidy
+          # install the local cli latest
+          cd ./spider_cli && cargo install  --path . && cd ../
+      - name: Run Benchmarks
+        run: cargo bench

--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -5,3 +5,4 @@ node-crawler.js
 go-crolly.go
 go.mod
 go.sum
+output.txt

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-spider = { version = "1.5.5", path = "../spider" }
+spider = { version = "1.6.0", path = "../spider" }
 criterion = "0.3"
 
 [[bench]]

--- a/benches/crawl.rs
+++ b/benches/crawl.rs
@@ -10,7 +10,7 @@ pub fn bench_speed(c: &mut Criterion) {
     let go_crawl_script = go_crolly::gen_crawl();
     let mut group = c.benchmark_group("crawl-speed");
         
-    group.sample_size(10).measurement_time(Duration::new(85, 0) + Duration::from_millis(500));
+    group.sample_size(10).measurement_time(Duration::new(180, 0) + Duration::from_millis(500));
     group.bench_function("Rust[spider]: with crawl 10 times", |b| b.iter(||Command::new("spider")
         .args(["--delay", "0", "--domain", "https://rsseau.fr", "crawl"])
         .output()

--- a/benches/go_crolly.rs
+++ b/benches/go_crolly.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 
 pub fn crawl_stub() -> String {
     r#"
-    package main
+    package spider
 
     import (
         "fmt"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.5.5"
+version = "1.6.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -15,7 +15,7 @@ publish = false
 maintenance = { status = "as-is" }
 
 [dependencies.spider]
-version = "1.5.5"
+version = "1.6.0"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.5.5"
+version = "1.6.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -15,7 +15,7 @@ edition = "2018"
 maintenance = { status = "as-is" }
 
 [dependencies]
-reqwest = { version = "0.11.10" }
+reqwest = { version = "0.11.10", features = ["blocking"] }
 scraper = "0.12"
 robotparser-fork = "0.10.5"
 url = "2.2"

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -91,7 +91,7 @@ fn parse_links() {
         .unwrap();
 
     let link_result = "https://choosealicense.com/";
-    let html = fetch_page_html(&link_result, &client).unwrap();
+    let html = fetch_page_html(&link_result, &client);
     let page: Page = Page::new(&link_result, &html);
 
     assert!(
@@ -111,7 +111,7 @@ fn test_abs_path() {
         .build()
         .unwrap();
     let link_result = "https://choosealicense.com/";
-    let html = fetch_page_html(&link_result, &client).unwrap();
+    let html = fetch_page_html(&link_result, &client);
     let page: Page = Page::new(&link_result, &html);
 
     assert_eq!(

--- a/spider/src/utils.rs
+++ b/spider/src/utils.rs
@@ -1,8 +1,18 @@
-pub use crate::reqwest::{Client, Error};
+pub use crate::reqwest::blocking::{Client};
+use reqwest::StatusCode;
 
-#[tokio::main]
-pub async fn fetch_page_html(url: &str, client: &Client) -> Result<String, Error> {
-    let body = client.get(url).send().await?.text().await?;
+pub fn fetch_page_html(url: &str, client: &Client) -> String {
+    let mut body = String::new();
 
-    Ok(body)
+    // silence errors for top level logging
+    match client.get(url).send() {
+        Ok(res) if res.status() == StatusCode::OK => match res.text() {
+            Ok(text) => body = text,
+            Err(_) => {},
+        },
+        Ok(_) => (),
+        Err(_) => {}
+    }
+
+    body
 }

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.5.5"
+version = "1.6.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -23,7 +23,7 @@ quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.5.5"
+version = "1.6.0"
 path = "../spider"
 default-features = false
 


### PR DESCRIPTION
1. fix mixing async runtime with blocking dispatch causing use of reqwest pool_max_idle_per_host which does not dispatch properly upon the async task completion outside the current thread. 

![Screen Shot 2022-04-21 at 10 20 50 AM](https://user-images.githubusercontent.com/8095978/164478790-01018fdb-73da-49cc-b558-0ed53b00b2c0.png)

-- TODO

Move `crawl` to fully async api with `crawl_sync` or blocking counter part.

Now the sync bench marks can properly be compared against node, go, and rust for crawling.
