### PR TITLE
fix(selectors): add resources to ignore list to handle main formats

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-spider = { version = "1.7.13", path = "../spider" }
+spider = { version = "1.7.14", path = "../spider" }
 criterion = "0.3"
 
 [[bench]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.7.13"
+version = "1.7.14"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -15,7 +15,7 @@ publish = false
 maintenance = { status = "as-is" }
 
 [dependencies.spider]
-version = "1.7.13"
+version = "1.7.14"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.7.13"
+version = "1.7.14"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -25,6 +25,7 @@ tokio = { version = "^1.17.0", features = [ "rt-multi-thread", "net", "macros", 
 regex = { version = "^1.5.0", optional = true }
 hashbrown = { version = "0.12" }
 log = "0.4.16"
+lazy_static = "1.4.0"
 
 [features]
 regex = ["dep:regex"]

--- a/spider/README.md
+++ b/spider/README.md
@@ -16,7 +16,7 @@ This is a basic blocking example crawling a web page, add spider to your `Cargo.
 
 ```toml
 [dependencies]
-spider = "1.7.13"
+spider = "1.7.14"
 ```
 
 And then the code:
@@ -57,7 +57,7 @@ There is an optional "regex" crate that can be enabled:
 
 ```toml
 [dependencies]
-spider = { version = "1.7.13", features = ["regex"] }
+spider = { version = "1.7.14", features = ["regex"] }
 ```
 
 ```rust,no_run

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -7,6 +7,8 @@ extern crate tokio;
 extern crate url;
 extern crate hashbrown;
 extern crate log;
+#[macro_use]
+extern crate lazy_static;
 
 /// Configuration structure for `Website`
 pub mod configuration;

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.7.13"
+version = "1.7.14"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -24,7 +24,7 @@ quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.7.13"
+version = "1.7.14"
 path = "../spider"
 default-features = false
 


### PR DESCRIPTION
1. adds full media resource ignore list.
1. move evaluation to const out of runtime for non dynamic selectors
1. bump v1.7.14
