### PR TITLE
feat(scrape): add html scrape ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![crate version](https://img.shields.io/crates/v/spider.svg)
 
-The fastest web indexer. (SpiderBot)
+The fastest web crawler and indexer.
 
 ## Getting Started
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-spider = { version = "1.7.23", path = "../spider" }
+spider = { version = "1.8.0", path = "../spider" }
 criterion = "0.3"
 
 [[bench]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.7.23"
+version = "1.8.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -15,7 +15,7 @@ publish = false
 maintenance = { status = "as-is" }
 
 [dependencies.spider]
-version = "1.7.23"
+version = "1.8.0"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.7.23"
+version = "1.8.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"

--- a/spider/README.md
+++ b/spider/README.md
@@ -16,7 +16,7 @@ This is a basic blocking example crawling a web page, add spider to your `Cargo.
 
 ```toml
 [dependencies]
-spider = "1.7.23"
+spider = "1.8.0"
 ```
 
 And then the code:
@@ -57,7 +57,7 @@ There is an optional "regex" crate that can be enabled:
 
 ```toml
 [dependencies]
-spider = { version = "1.7.23", features = ["regex"] }
+spider = { version = "1.8.0", features = ["regex"] }
 ```
 
 ```rust,no_run

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -56,6 +56,11 @@ impl Page {
         &self.url
     }
 
+    /// Html getter for page.
+    pub fn get_html(&self) -> &String {
+        &self.html
+    }
+
     /// HTML returned from Scraper.
     fn parse_html(&self) -> Html {
         Html::parse_document(&self.html)

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.7.23"
+version = "1.8.0"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -18,13 +18,14 @@ maintenance = { status = "as-is" }
 [dependencies]
 clap = { version = "3.1.9", features = ["derive"] }
 env_logger = "0.9.0"
+serde_json = "1.0.81"
 
 [build-dependencies]
 quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.7.23"
+version = "1.8.0"
 path = "../spider"
 default-features = false
 

--- a/spider_cli/src/options/sub_command.rs
+++ b/spider_cli/src/options/sub_command.rs
@@ -2,7 +2,7 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// crawl the website.
+    /// crawl the website extracting links.
     CRAWL {
         /// sequentially one by one crawl pages
         #[clap(short, long)]
@@ -10,5 +10,14 @@ pub enum Commands {
         /// stdout all links crawled
         #[clap(short, long)]
         output_links: bool,
+    },
+    /// scrape the website extracting html and links.
+    SCRAPE {
+        /// stdout all pages links crawled
+        #[clap(short, long)]
+        output_links: bool,
+        /// stdout all pages html crawled
+        #[clap(long)]
+        output_html: bool,
     },
 }


### PR DESCRIPTION
1. add multi threaded html scraping ability and expose html for extracting.

-----
example of `--output-links` and `--output-html` sub commands for the new `scrape` API. Examples use `> res.json` to pipe the output to a file. 

output with links
```
spider  --domain https://a11ywatch.com scrape --output-links > res.json
```
output with html
```
spider  --domain https://a11ywatch.com scrape --output-links --output-html > res.json
```
![Screen Shot 2022-05-16 at 10 44 24 AM](https://user-images.githubusercontent.com/8095978/168619600-17f8f58a-4c56-4803-a60c-069c3d8f703c.png)

![Screen Shot 2022-05-16 at 10 45 36 AM](https://user-images.githubusercontent.com/8095978/168619888-403f9833-5a4c-453e-94c9-3491aabb1438.png)

