### PR TITLE
bench(crawl): add concurrent benches

### DIFF
--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -9,15 +9,20 @@
 
 ```sh
 ----------------------
+linux ubuntu-latest
 2-core CPU
 7 GB of RAM memory
 14 GB of SSD disk space
 -----------------------
 
 Test url: `https://rsseau.fr`
+
+15 pages
 ```
 
 ### crawl-speed
+
+runs with 10 samples:
 
 |                                          | `libraries`               |
 | :--------------------------------------- | :------------------------ |
@@ -25,3 +30,14 @@ Test url: `https://rsseau.fr`
 | **`Go[crolly]: crawl 10 samples`**       | `2.9417 s` (✅ **1.00x**) |
 | **`Node.js[crawler]: crawl 10 samples`** | `2.9992 s` (✅ **1.00x**) |
 | **`C[wget]: crawl 10 samples`**          | `12.019 s` (✅ **1.00x**) |
+
+### crawl-speed-concurrentx10
+
+10 concurrent runs with 10 samples:
+
+|                                          | `libraries`                |
+| :--------------------------------------- | :------------------------- |
+| **`Rust[spider]: crawl 10 samples`**     | `2.8644 s` (✅ **10.00x**) |
+| **`Go[crolly]: crawl 10 samples`**       | `4.2235 s` (✅ **10.00x**) |
+| **`Node.js[crawler]: crawl 10 samples`** | `14.461 s` (✅ **10.00x**) |
+| **`C[wget]: crawl 10 samples`**          | `16.181 s` (✅ **10.00x**) |

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -1,6 +1,6 @@
-use std::process::{Command};
-pub mod node_crawler;
+use std::process::Command;
 pub mod go_crolly;
+pub mod node_crawler;
 
 /// build executables for bench marks
 pub fn main() {
@@ -8,15 +8,36 @@ pub fn main() {
     go_crolly::gen_crawl();
 
     // install go deps
-    Command::new("go").arg("mod").arg("init").arg("example.com/gospider").output().expect("go init failed");
-    Command::new("go").arg("get").arg("-u").arg("github.com/gocolly/colly/v2").output().expect("go get colly failed");
-    Command::new("go").arg("mod").arg("tidy").output().expect("go tidy failed");
-    Command::new("go").arg("build").output().expect("go build failed");
+    Command::new("go")
+        .args(["mod", "init", "example.com/gospider"])
+        .output()
+        .expect("go init failed");
+    Command::new("go")
+        .args(["get", "-u", "github.com/gocolly/colly/v2"])
+        .output()
+        .expect("go get colly failed");
+    Command::new("go")
+        .args(["mod", "tidy"])
+        .output()
+        .expect("go tidy failed");
+    Command::new("go")
+        .arg("build")
+        .output()
+        .expect("go build failed");
     // install node deps
-    Command::new("npm").arg("init").arg("-y").output().expect("go init failed");
-    Command::new("npm").arg("i").arg("crawler").arg("--save").output().expect("go init failed");
+    Command::new("npm")
+        .args(["init", "-y"])
+        .output()
+        .expect("npm init failed");
+    Command::new("npm")
+        .args(["i", "crawler", "--save"])
+        .output()
+        .expect("npm install crawler failed");
 
     if cfg!(target_os = "linux") {
-        Command::new("apt-get").arg("install").arg("wget").output().expect("wget install failed");
+        Command::new("apt-get")
+            .args(["install", "wget"])
+            .output()
+            .expect("wget install failed");
     }
 }

--- a/benches/crawl.rs
+++ b/benches/crawl.rs
@@ -1,7 +1,9 @@
-use criterion::{criterion_group, black_box, criterion_main, Criterion};
-use std::process::{Command};
-pub mod node_crawler;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::process::Command;
 pub mod go_crolly;
+pub mod node_crawler;
+use std::thread;
+use std::time::Duration;
 
 /// bench spider crawling between different libs
 pub fn bench_speed(c: &mut Criterion) {
@@ -10,28 +12,164 @@ pub fn bench_speed(c: &mut Criterion) {
     let query = "https://rsseau.fr";
     let sample_title = format!("crawl {} samples", sample_count);
 
-    group.sample_size(10);
-    group.bench_function(format!("Rust[spider]: {}", sample_title), |b| b.iter(||black_box(Command::new("spider")
-        .args(["--delay", "0", "--domain", &query, "crawl"])
-        .output()
-        .expect("rust command failed to start"))
-    ));
-    group.bench_function(format!("Go[crolly]: {}", sample_title), |b| b.iter(||black_box(Command::new("./gospider")
-        .output()
-        .expect("go command failed to start"))
-    ));
-    group.bench_function(format!("Node.js[crawler]: {}", sample_title), |b| b.iter(|| black_box(Command::new("node")
-        .arg("./node-crawler.js")
-        .output()
-        .expect("node command failed to start"))
-    ));
-    group.bench_function(format!("C[wget]: {}", sample_title), |b| b.iter(|| black_box(Command::new("wget")
-        .args(["-4", "--recursive", "--no-parent", "--ignore-tags=img,link,script", "--spider", "-q", &query])
-        .output()
-        .expect("wget command failed to start"))
-    ));
+    group.sample_size(sample_count);
+    group.bench_function(format!("Rust[spider]: {}", sample_title), |b| {
+        b.iter(|| {
+            black_box(
+                Command::new("spider")
+                    .args(["--delay", "0", "--domain", &query, "crawl"])
+                    .output()
+                    .expect("rust command failed to start"),
+            )
+        })
+    });
+    group.bench_function(format!("Go[crolly]: {}", sample_title), |b| {
+        b.iter(|| {
+            black_box(
+                Command::new("./gospider")
+                    .output()
+                    .expect("go command failed to start"),
+            )
+        })
+    });
+    group.bench_function(format!("Node.js[crawler]: {}", sample_title), |b| {
+        b.iter(|| {
+            black_box(
+                Command::new("node")
+                    .arg("./node-crawler.js")
+                    .output()
+                    .expect("node command failed to start"),
+            )
+        })
+    });
+    group.bench_function(format!("C[wget]: {}", sample_title), |b| {
+        b.iter(|| {
+            black_box(
+                Command::new("wget")
+                    .args([
+                        "-4",
+                        "--recursive",
+                        "--no-parent",
+                        "--ignore-tags=img,link,script",
+                        "--spider",
+                        "-q",
+                        &query,
+                    ])
+                    .output()
+                    .expect("wget command failed to start"),
+            )
+        })
+    });
     group.finish();
 }
 
-criterion_group!(benches, bench_speed);
+/// bench spider crawling between different libs parallel 3x
+pub fn bench_speed_concurrent_x10(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crawl-speed-concurrent/libraries");
+    let sample_count = 10;
+    let query = "https://rsseau.fr";
+    let sample_title = format!("crawl {} samples", sample_count);
+    let concurrency_count: Vec<_> = (0..10).collect();
+
+    group.measurement_time(Duration::from_secs(85));
+    group.sample_size(sample_count);
+    group.bench_function(format!("Rust[spider]: {}", sample_title), |b| {
+        b.iter(|| {
+            let threads: Vec<_> = concurrency_count
+                .clone()
+                .into_iter()
+                .map(|_| {
+                    thread::spawn(move || {
+                        black_box(
+                            Command::new("spider")
+                                .args(["--delay", "0", "--domain", &query, "crawl"])
+                                .output()
+                                .expect("rust command failed to start"),
+                        );
+                    })
+                })
+                .collect();
+
+            for handle in threads {
+                handle.join().unwrap()
+            }
+        })
+    });
+    group.bench_function(format!("Go[crolly]: {}", sample_title), |b| {
+        b.iter(|| {
+            let threads: Vec<_> = concurrency_count
+                .clone()
+                .into_iter()
+                .map(|_| {
+                    thread::spawn(move || {
+                        black_box(
+                            Command::new("./gospider")
+                                .output()
+                                .expect("go command failed to start"),
+                        );
+                    })
+                })
+                .collect();
+
+            for handle in threads {
+                handle.join().unwrap()
+            }
+        })
+    });
+    group.bench_function(format!("Node.js[crawler]: {}", sample_title), |b| {
+        b.iter(|| {
+            let threads: Vec<_> = concurrency_count
+                .clone()
+                .into_iter()
+                .map(|_| {
+                    thread::spawn(move || {
+                        black_box(
+                            Command::new("node")
+                                .arg("./node-crawler.js")
+                                .output()
+                                .expect("node command failed to start"),
+                        );
+                    })
+                })
+                .collect();
+
+            for handle in threads {
+                handle.join().unwrap()
+            }
+        })
+    });
+    group.bench_function(format!("C[wget]: {}", sample_title), |b| {
+        b.iter(|| {
+            let threads: Vec<_> = concurrency_count
+                .clone()
+                .into_iter()
+                .map(|_| {
+                    thread::spawn(move || {
+                        black_box(
+                            Command::new("wget")
+                                .args([
+                                    "-4",
+                                    "--recursive",
+                                    "--no-parent",
+                                    "--ignore-tags=img,link,script",
+                                    "--spider",
+                                    "-q",
+                                    &query,
+                                ])
+                                .output()
+                                .expect("wget command failed to start"),
+                        );
+                    })
+                })
+                .collect();
+
+            for handle in threads {
+                handle.join().unwrap()
+            }
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_speed, bench_speed_concurrent_x10);
 criterion_main!(benches);

--- a/benches/go_crolly.rs
+++ b/benches/go_crolly.rs
@@ -37,12 +37,8 @@ pub fn gen_crawl() -> String {
     let file = File::create(&crawl_script).expect("create go crawl script");
     let mut file = BufWriter::new(file);
     let stub = crawl_stub();
-    file.write_all(stub.as_bytes()).expect("Unable to write data");
+    file.write_all(stub.as_bytes())
+        .expect("Unable to write data");
 
     crawl_script
 }
-
-
-
-
-

--- a/benches/node_crawler.rs
+++ b/benches/node_crawler.rs
@@ -56,7 +56,8 @@ pub fn gen_crawl() -> String {
     let mut file = BufWriter::new(file);
     let stub = crawl_stub();
 
-    file.write_all(stub.as_bytes()).expect("Unable to write data");
+    file.write_all(stub.as_bytes())
+        .expect("Unable to write data");
 
     crawl_script
 }


### PR DESCRIPTION
* add concurrent benches 10x
-- 

Benches are done on a small sized website with 15 pages. 
On the url `https://rsseau.fr`.

|   simultaneous                                       | `libraries`               |
| :--------------------------------------- | :------------------------ |
| **`Rust[spider]: crawl 10 samples`**     | `1.8375 s` (✅ **1.00x**) |
| **`Go[crolly]: crawl 10 samples`**       | `2.9417 s` (✅ **1.00x**) |
| **`Node.js[crawler]: crawl 10 samples`** | `2.9992 s` (✅ **1.00x**) |
| **`C[wget]: crawl 10 samples`**          | `12.019 s` (✅ **1.00x**) |

|     concurrent                                     | `libraries`                |
| :--------------------------------------- | :------------------------- |
| **`Rust[spider]: crawl 10 samples`**     | `2.8644 s` (✅ **10.00x**) |
| **`Go[crolly]: crawl 10 samples`**       | `4.2235 s` (✅ **10.00x**) |
| **`Node.js[crawler]: crawl 10 samples`** | `14.461 s` (✅ **10.00x**) |
| **`C[wget]: crawl 10 samples`**          | `16.181 s` (✅ **10.00x**) |

nodejs concurrency makes perform suffer drastically.

The rust crate performs a drastically better across the rest of the choices when the website contains over 100+ pages and at 1,000 pages like HBO it's even higher. Cant fully complete the crawls without worrying about the larger website from blocking the ip so currently doing it manually after every couple of hours. Going to update the larger website crawl benches soon.



