### PR TITLE
chore(memory): fix memory leaks on robot parser

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.10.7"
+version = "1.10.8"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -20,7 +20,7 @@ env_logger = "0.9.0"
 htr = "0.5.23"
 
 [dependencies.spider]
-version = "1.10.7"
+version = "1.10.8"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.10.7"
+version = "1.10.8"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"

--- a/spider/README.md
+++ b/spider/README.md
@@ -16,7 +16,7 @@ This is a basic blocking example crawling a web page, add spider to your `Cargo.
 
 ```toml
 [dependencies]
-spider = "1.10.7"
+spider = "1.10.8"
 ```
 
 And then the code:
@@ -58,7 +58,7 @@ There is an optional "regex" crate that can be enabled:
 
 ```toml
 [dependencies]
-spider = { version = "1.10.7", features = ["regex"] }
+spider = { version = "1.10.8", features = ["regex"] }
 ```
 
 ```rust,no_run
@@ -83,5 +83,5 @@ Currently we have two optional feature flags. Regex blacklisting and randomizing
 
 ```toml
 [dependencies]
-spider = { version = "1.10.7", features = ["regex", "ua_generator"] }
+spider = { version = "1.10.8", features = ["regex", "ua_generator"] }
 ```

--- a/spider/src/packages/robotparser.rs
+++ b/spider/src/packages/robotparser.rs
@@ -23,7 +23,6 @@
 //! }
 //! ```
 
-use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -37,9 +36,9 @@ use url::Url;
 /// A rule line is a single "Allow:" (allowance==True) or "Disallow:"
 /// (allowance==False) followed by a path."""
 #[derive(Debug, Eq, PartialEq, Clone)]
-struct RuleLine<'a> {
+struct RuleLine {
     /// Path of the rule
-    path: Cow<'a, str>,
+    path: String,
     /// Is the rule allowed?
     allowance: bool,
 }
@@ -55,34 +54,30 @@ pub struct RequestRate {
 
 /// An entry has one or more user-agents and zero or more rulelines
 #[derive(Debug, Eq, PartialEq, Clone)]
-struct Entry<'a> {
+struct Entry {
     /// Multiple user agents to use
     useragents: RefCell<Vec<String>>,
     /// Rules that should be ignored
-    rulelines: RefCell<Vec<RuleLine<'a>>>,
+    rulelines: RefCell<Vec<RuleLine>>,
     /// Time to wait in between crawls
     crawl_delay: Option<Duration>,
-    /// The sitemaps for the website
-    sitemaps: Vec<Url>,
     /// The request rate to respect
     req_rate: Option<RequestRate>,
 }
 
 /// robots.txt file parser
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct RobotFileParser<'a> {
+pub struct RobotFileParser {
     /// Entire robots.txt list of urls
-    entries: RefCell<Vec<Entry<'a>>>,
+    entries: RefCell<Vec<Entry>>,
     /// Base entry to list
-    default_entry: RefCell<Entry<'a>>,
+    default_entry: RefCell<Entry>,
     /// Dis-allow links reguardless of robots.txt
     disallow_all: Cell<bool>,
     /// Allow links reguardless of robots.txt
     allow_all: Cell<bool>,
     /// Url of the website
     url: Url,
-    /// Domain Hostname
-    host: String,
     /// Domain url path
     path: String,
     /// Time last checked robots.txt file
@@ -91,10 +86,8 @@ pub struct RobotFileParser<'a> {
     pub user_agent: String,
 }
 
-impl<'a> RuleLine<'a> {
-    fn new<S>(path: S, allowance: bool) -> RuleLine<'a>
-    where
-        S: Into<Cow<'a, str>>,
+impl RuleLine {
+    fn new(path: String, allowance: bool) -> RuleLine
     {
         let path = path.into();
         let mut allow = allowance;
@@ -113,14 +106,13 @@ impl<'a> RuleLine<'a> {
     }
 }
 
-impl<'a> Entry<'a> {
+impl Entry {
     /// Base collection to manage robot.txt data
-    fn new() -> Entry<'a> {
+    fn new() -> Entry {
         Entry {
             useragents: RefCell::new(vec![]),
             rulelines: RefCell::new(vec![]),
             crawl_delay: None,
-            sitemaps: Vec::new(),
             req_rate: None,
         }
     }
@@ -156,11 +148,11 @@ impl<'a> Entry<'a> {
     /// Add to user agent list
     fn push_useragent(&self, useragent: &str) {
         let mut useragents = self.useragents.borrow_mut();
-        useragents.push(useragent.to_lowercase().to_owned());
+        useragents.push(useragent.to_lowercase());
     }
 
     /// Add rule to list
-    fn push_ruleline(&self, ruleline: RuleLine<'a>) {
+    fn push_ruleline(&self, ruleline: RuleLine) {
         let mut rulelines = self.rulelines.borrow_mut();
         rulelines.push(ruleline);
     }
@@ -168,7 +160,7 @@ impl<'a> Entry<'a> {
     /// Determine if user agent exist
     fn has_useragent(&self, useragent: &str) -> bool {
         let useragents = self.useragents.borrow();
-        useragents.contains(&useragent.to_owned())
+        useragents.contains(&useragent.to_string())
     }
 
     /// Is the user-agent list empty?
@@ -188,18 +180,6 @@ impl<'a> Entry<'a> {
         self.crawl_delay
     }
 
-    /// Add sitemap to list
-    fn add_sitemap(&mut self, url: &str) {
-        if let Ok(url) = Url::parse(url) {
-            self.sitemaps.push(url);
-        }
-    }
-
-    /// Determine sitemaps for website
-    fn get_sitemaps(&self) -> Vec<Url> {
-        self.sitemaps.clone()
-    }
-
     /// Establish request rates between robots.txt crawling sitemaps
     fn set_req_rate(&mut self, req_rate: RequestRate) {
         self.req_rate = Some(req_rate);
@@ -211,24 +191,24 @@ impl<'a> Entry<'a> {
     }
 }
 
-impl<'a> Default for Entry<'a> {
-    fn default() -> Entry<'a> {
+impl Default for Entry {
+    fn default() -> Entry {
         Entry::new()
     }
 }
 
-impl<'a> RobotFileParser<'a> {
+impl RobotFileParser {
     /// Establish a new robotparser for a website domain
-    pub fn new<T: AsRef<str>>(url: T) -> RobotFileParser<'a> {
+    pub fn new<T: AsRef<str>>(url: T) -> RobotFileParser {
         let parsed_url = Url::parse(url.as_ref()).unwrap();
+
         RobotFileParser {
             entries: RefCell::new(vec![]),
             default_entry: RefCell::new(Entry::new()),
             disallow_all: Cell::new(false),
             allow_all: Cell::new(false),
             url: parsed_url.clone(),
-            host: parsed_url.host_str().unwrap().to_owned(),
-            path: parsed_url.path().to_owned(),
+            path: parsed_url.path().to_string(),
             last_checked: Cell::new(0i64),
             user_agent: String::from("robotparser-rs"),
         }
@@ -255,16 +235,15 @@ impl<'a> RobotFileParser<'a> {
     /// Sets the URL referring to a robots.txt file.
     pub fn set_url<T: AsRef<str>>(&mut self, url: T) {
         let parsed_url = Url::parse(url.as_ref()).unwrap();
-        self.url = parsed_url.clone();
-        self.host = parsed_url.host_str().unwrap().to_owned();
-        self.path = parsed_url.path().to_owned();
+        self.path = parsed_url.path().to_string();
+        self.url = parsed_url;
         self.last_checked.set(0i64);
     }
 
     /// Reads the robots.txt URL and feeds it to the parser.
     pub fn read(&self, client: &Client) {
         let request = client.get(self.url.clone());
-        let request = request.header(USER_AGENT, self.user_agent.to_owned());
+        let request = request.header(USER_AGENT, &self.user_agent);
         let mut res = match request.send() {
             Ok(res) => res,
             Err(_) => {
@@ -295,7 +274,7 @@ impl<'a> RobotFileParser<'a> {
         self.parse(&lines);
     }
 
-    fn _add_entry(&self, entry: Entry<'a>) {
+    fn _add_entry(&self, entry: Entry) {
         if entry.has_useragent("*") {
             // the default entry is considered last
             let mut default_entry = self.default_entry.borrow_mut();
@@ -355,7 +334,7 @@ impl<'a> RobotFileParser<'a> {
             if parts.len() == 2 {
                 let part0 = parts[0].trim().to_lowercase();
                 let part1 = String::from_utf8(percent_decode(parts[1].trim().as_bytes()).collect())
-                    .unwrap_or("".to_owned());
+                    .unwrap_or("".to_string());
                 match part0 {
                     ref x if x.to_lowercase() == "user-agent" => {
                         if state == 2 {
@@ -392,7 +371,6 @@ impl<'a> RobotFileParser<'a> {
                     }
                     ref x if x.to_lowercase() == "sitemap" => {
                         if state != 0 {
-                            entry.add_sitemap(&part1);
                             state = 2;
                         }
                     }
@@ -442,10 +420,10 @@ impl<'a> RobotFileParser<'a> {
         // search for given user agent matches
         // the first match counts
         let decoded_url = String::from_utf8(percent_decode(url.trim().as_bytes()).collect())
-            .unwrap_or("".to_owned());
+            .unwrap_or("".to_string());
         let url_str = match decoded_url {
-            ref u if !u.is_empty() => u.to_owned(),
-            _ => "/".to_owned(),
+            ref u if !u.is_empty() => u,
+            _ => "/",
         };
         let entries = self.entries.borrow();
         for entry in &*entries {
@@ -486,21 +464,6 @@ impl<'a> RobotFileParser<'a> {
         }
 
         None
-    }
-
-    /// Returns the sitemaps for this user agent as a `Vec<Url>`.
-    pub fn get_sitemaps<T: AsRef<str>>(&self, useragent: T) -> Vec<Url> {
-        let useragent = useragent.as_ref();
-        if self.last_checked.get() == 0 {
-            return Vec::new();
-        }
-        let entries = self.entries.borrow();
-        for entry in &*entries {
-            if entry.applies_to(useragent) {
-                return entry.get_sitemaps();
-            }
-        }
-        vec![]
     }
 
     /// Returns the request rate for this user agent as a `RequestRate`, or None if not request rate is defined

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -24,7 +24,7 @@ use tokio::time::sleep;
 /// }
 /// ```
 #[derive(Debug)]
-pub struct Website<'a> {
+pub struct Website {
     /// configuration properties for website.
     pub configuration: Configuration,
     /// this is a start URL given when instanciate with `new`.
@@ -38,12 +38,12 @@ pub struct Website<'a> {
     /// callback when a link is found.
     pub on_link_find_callback: fn(String) -> String,
     /// Robot.txt parser holder.
-    robot_file_parser: RobotFileParser<'a>,
+    robot_file_parser: RobotFileParser,
 }
 
 type Message = HashSet<String>;
 
-impl<'a> Website<'a> {
+impl Website {
     /// Initialize Website object with a start link to crawl.
     pub fn new(domain: &str) -> Self {
         Self {
@@ -305,10 +305,6 @@ impl<'a> Website<'a> {
         }
     }
     
-}
-
-impl<'a> Drop for Website<'a> {
-    fn drop(&mut self) {}
 }
 
 // blocking sleep keeping thread alive

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.10.7"
+version = "1.10.8"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/madeindjs/spider"
@@ -25,7 +25,7 @@ quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.10.7"
+version = "1.10.8"
 path = "../spider"
 default-features = false
 

--- a/spider_cli/README.md
+++ b/spider_cli/README.md
@@ -34,7 +34,7 @@ spider --domain https://choosealicense.com crawl -o > spider_choosealicense.json
 ```
 
 ```sh
-spider_cli 1.10.7
+spider_cli 1.10.8
 madeindjs <contact@rousseau-alexandre.fr>, j-mendez <jeff@a11ywatch.com>
 Multithreaded web crawler written in Rust.
 


### PR DESCRIPTION
The reference imp of the robot parser causes leaks on runs due to the static lifetimes.

-- The crawler is setup to only handle pages that are in the UI.

We need to switch the parser to use https://github.com/Folyd/robotstxt and remove the reference imp.

Some more details why below:

https://doc.rust-lang.org/book/ch15-06-reference-cycles.html