### PR TITLE
bench(crawl): add direct spider speed test

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,10 +24,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Benchmark Dependencies
-        run: |
-          # install the local cli latest
-          cd ./spider_cli && cargo install  --path . && cd ../
-          cd benches && cargo build
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Run Benchmarks
         run: cargo bench

--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -8,3 +8,4 @@ go.sum
 output.txt
 gospider
 build
+portfolio

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -7,6 +7,8 @@
 
 ## Benchmark Results
 
+### AMD
+
 ```sh
 ----------------------
 linux ubuntu-latest
@@ -14,37 +16,72 @@ linux ubuntu-latest
 7 GB of RAM memory
 14 GB of SSD disk space
 -----------------------
-
-Test url: `https://rsseau.fr`
+Url: `https://rsseau.fr` locally.
 
 15 pages
 ```
 
-### crawl-speed
+#### crawl-speed
 
 runs with 10 samples:
 
-|                                          | `libraries`               |
-| :--------------------------------------- | :------------------------ |
-| **`Rust[spider]: crawl 10 samples`**     | `1.5528 s` (✅ **1.00x**) |
-| **`Go[crolly]: crawl 10 samples`**       | `2.9417 s` (✅ **1.00x**) |
-| **`Node.js[crawler]: crawl 10 samples`** | `2.9992 s` (✅ **1.00x**) |
-| **`C[wget]: crawl 10 samples`**          | `12.019 s` (✅ **1.00x**) |
+|                                          | `libraries`                |
+| :--------------------------------------- | :------------------------- |
+| **`Rust[spider]: crawl 10 samples`**     | `44.130 ms` (✅ **1.00x**) |
+| **`Go[crolly]: crawl 10 samples`**       | `412.75 ms` (✅ **1.00x**) |
+| **`Node.js[crawler]: crawl 10 samples`** | `506.01 ms` (✅ **1.00x**) |
+| **`C[wget]: crawl 10 samples`**          | `44.592 ms` (✅ **1.00x**) |
 
-### crawl-speed-concurrentx10
+#### crawl-speed-concurrentx10
 
 10 concurrent runs with 10 samples:
 
+|                                          | `libraries`                 |
+| :--------------------------------------- | :-------------------------- |
+| **`Rust[spider]: crawl 10 samples`**     | `312.56 ms` (✅ **10.00x**) |
+| **`Go[crolly]: crawl 10 samples`**       | `753.39 ms` (✅ **10.00x**) |
+| **`Node.js[crawler]: crawl 10 samples`** | `3.2587 s` (✅ **10.00x**)  |
+| **`C[wget]: crawl 10 samples`**          | `347.13 ms` (✅ **10.00x**) |
+
+### Arm64
+
+```sh
+----------------------
+MacBookPro18,2 Apple M1 Max
+10-core CPU
+64 GB of RAM memory
+1 TB of SSD disk space
+-----------------------
+Url: `https://rsseau.fr` locally.
+
+15 pages
+```
+
+#### crawl-speed
+
 |                                          | `libraries`                |
 | :--------------------------------------- | :------------------------- |
-| **`Rust[spider]: crawl 10 samples`**     | `1.9368 s` (✅ **10.00x**) |
-| **`Go[crolly]: crawl 10 samples`**       | `3.4310 s` (✅ **10.00x**) |
-| **`Node.js[crawler]: crawl 10 samples`** | `22.174 s` (✅ **10.00x**) |
-| **`C[wget]: crawl 10 samples`**          | `20.952 s` (✅ **10.00x**) |
+| **`Rust[spider]: crawl 10 samples`**     | `5.66 ms` (✅ **1.00x**)   |
+| **`Go[crolly]: crawl 10 samples`**       | `9.74 s` (✅ **1.00x**)    |
+| **`Node.js[crawler]: crawl 10 samples`** | `388.07 ms` (✅ **1.00x**) |
+| **`C[wget]: crawl 10 samples`**          | `51.434 ms` (✅ **1.00x**) |
+
+#### crawl-speed-concurrentx10
+
+|                                                     | `libraries`                |
+| :-------------------------------------------------- | :------------------------- |
+| **`Rust[spider]: crawl concurrent 10 samples`**     | `279.67 ms` (✅ **1.00x**) |
+| **`Go[crolly]: crawl concurrent 10 samples`**       | `10.47 s` (✅ **1.00x**)   |
+| **`Node.js[crawler]: crawl concurrent 10 samples`** | `658.82 ms` (✅ **1.00x**) |
+| **`C[wget]: crawl concurrent 10 samples`**          | `58.434 ms` (✅ **1.00x**) |
 
 The concurrent benchmarks are averaged across 10 individual runs for 10 concurrent crawls with 10 sample counts.
 
 In order for us to get better metrics we need to test the concurrency and simultaneous runs with a larger website and favorably a website that can spin up inside the local container so latency is not being tracked. The multi-threaded crawling capabilities shines bright the larger the website.
 Currently even with a small website this package still runs faster than the top OSS crawlers to date.
 
-_Note_: Nodejs concurrency heavily impacts each additional run.
+_*Note*_
+
+Nodejs concurrency heavily impacts each additional run when networking is enabled and tested on a non local website.
+
+Wget performance is impacted when using networking outside of local connections.

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -3,6 +3,7 @@ name = "benches"
 version = "0.0.0"
 publish = false
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,3 +11,8 @@ criterion = { version = "0.3.5", features = ["html_reports"] }
 name = "crawl"
 path = "crawl.rs"
 harness = false
+
+[dependencies.spider]
+version = "1.11.3"
+path = "../spider"
+default-features = false

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-
 pub mod go_crolly;
 pub mod node_crawler;
 
@@ -7,6 +6,35 @@ pub mod node_crawler;
 pub fn main() {
     node_crawler::gen_crawl();
     go_crolly::gen_crawl();
+
+    // clone the swr website for testing
+    Command::new("git")
+        .args([
+            "clone",
+            "https://github.com/madeindjs/portfolio.git",
+        ])
+        .output()
+        .expect("git clone command failed");
+
+    Command::new("npm")
+        .args([
+            "--prefix",
+            "./portfolio",
+            "install",
+            "--force",
+        ])
+        .output()
+        .expect("npm install command failed");
+
+    Command::new("npm")
+        .args([
+            "--prefix",
+            "./portfolio",
+            "run",
+            "build",
+        ])
+        .output()
+        .expect("npm build command failed");
 
     // install go deps
     Command::new("go")

--- a/benches/crawl.rs
+++ b/benches/crawl.rs
@@ -4,6 +4,7 @@ pub mod node_crawler;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::process::Command;
 use std::thread;
+use spider::website::Website;
 
 /// bench crawling between different libs
 pub fn bench_speed(c: &mut Criterion) {
@@ -14,12 +15,14 @@ pub fn bench_speed(c: &mut Criterion) {
 
     group.sample_size(sample_count);
     group.bench_function(format!("Rust[spider]: {}", sample_title), |b| {
+        
         b.iter(|| {
+            let mut website: Website = Website::new(&query);
+    
+            website.configuration.delay = 0;
+
             black_box(
-                Command::new("spider")
-                    .args(["--delay", "0", "--domain", &query, "crawl"])
-                    .output()
-                    .expect("rust command failed to start"),
+                website.crawl(),
             )
         })
     });

--- a/benches/go_crolly.rs
+++ b/benches/go_crolly.rs
@@ -19,7 +19,7 @@ pub fn crawl_stub() -> String {
         })
 
         c.OnHTML(`a[href^="/"]:not([href$=".png"]):not([href$=".jpg"]):not([href$=".mp4"]):not([href$=".mp3"]):not([href$=".gif"]),
-        a[href^="https://rsseau.fr"]:not([href$=".png"]):not([href$=".jpg"]):not([href$=".mp4"]):not([href$=".mp3"]):not([href$=".gif"])`, func(e *colly.HTMLElement) {
+        a[href^="http://localhost:3000"]:not([href$=".png"]):not([href$=".jpg"]):not([href$=".mp4"]):not([href$=".mp3"]):not([href$=".gif"])`, func(e *colly.HTMLElement) {
             e.Request.Visit(e.Attr("href"))
         })
     
@@ -27,7 +27,7 @@ pub fn crawl_stub() -> String {
             fmt.Println("- visiting ", r.URL)
         })
     
-        c.Visit("https://rsseau.fr")
+        c.Visit("http://localhost:3000")
     }
     "#.to_string()
 }

--- a/benches/node_crawler.rs
+++ b/benches/node_crawler.rs
@@ -6,7 +6,7 @@ pub fn crawl_stub() -> String {
 
     const Crawler = require("crawler");
 
-    const base = "https://rsseau.fr";
+    const base = "http://localhost:3000";
     const crawledPages = { [base]: true };
     const ignoreSelector = `:not([href$=".png"]):not([href$=".jpg"]):not([href$=".mp4"]):not([href$=".mp3"]):not([href$=".gif"])`;
     

--- a/examples/download_to_react.rs
+++ b/examples/download_to_react.rs
@@ -1,18 +1,18 @@
 //! `cargo run --example download_to_react`
-extern crate env_logger;
-extern crate spider;
-extern crate htr;
 extern crate convert_case;
+extern crate env_logger;
+extern crate htr;
+extern crate spider;
 
 use spider::utils::log;
 use spider::website::Website;
 
+use convert_case::{Case, Casing};
 use env_logger::Env;
+use htr::convert_to_react;
+use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::env;
-use convert_case::{Case, Casing};
-use htr::convert_to_react;
 
 fn main() {
     let target_dir = env::var("CARGO_TARGET_DIR").unwrap_or("./target".to_string());
@@ -58,7 +58,7 @@ fn main() {
             .truncate(true)
             .open(&format!("{}/downloads/{}.tsx", target_dir, download_file))
             .expect("Unable to open file");
-    
+
         let download_file = download_file.to_case(Case::Camel);
         let download_file = download_file[0..1].to_uppercase() + &download_file[1..];
 

--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -17,7 +17,7 @@ pub struct Configuration {
     /// Allow sub-domains.
     pub subdomains: bool,
     /// Allow all tlds for domain.
-    pub tld: bool, 
+    pub tld: bool,
     /// List of pages to not crawl. [optional: regex pattern matching]
     pub blacklist_url: Vec<String>,
     /// User-Agent
@@ -25,9 +25,8 @@ pub struct Configuration {
     /// Polite crawling delay in milli seconds.
     pub delay: u64,
     /// How many request can be run simultaneously.
-    pub concurrency: usize
+    pub concurrency: usize,
 }
-
 
 /// get the user agent from the top agent list randomly.
 #[cfg(any(feature = "ua_generator"))]
@@ -40,11 +39,7 @@ pub fn get_ua() -> String {
 pub fn get_ua() -> String {
     use std::env;
 
-    format!(
-        "{}/{}",
-        env!("CARGO_PKG_NAME"), 
-        env!("CARGO_PKG_VERSION")
-    )
+    format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
 }
 
 impl Configuration {

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! [`crawl`]: website/struct.Website.html#method.crawl
 //! [`crawl_sync`]: website/struct.Website.html#method.crawl_sync
-//! 
+//!
 //! # Basic usage
 //!
 //! First, you will need to add `spider` to your `Cargo.toml`.
@@ -27,27 +27,27 @@
 //! Next, simply add the website url in the struct of website and crawl,
 //! you can also crawl sequentially.
 
+extern crate hashbrown;
+extern crate log;
 extern crate num_cpus;
 extern crate rayon;
 extern crate reqwest;
 extern crate scraper;
 extern crate tokio;
-extern crate url;
-extern crate hashbrown;
-extern crate log;
 #[cfg(feature = "ua_generator")]
 extern crate ua_generator;
+extern crate url;
 
 /// Configuration structure for `Website`.
 pub mod configuration;
+/// Internal packages customized.
+pub mod packages;
 /// A page scraped.
 pub mod page;
 /// Application utils.
 pub mod utils;
 /// A website to crawl.
 pub mod website;
-/// Internal packages customized.
-pub mod packages;
 
 #[cfg(feature = "regex")]
 /// Black list checking url exist with Regex.

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -1,8 +1,8 @@
-use scraper::{Html, Selector};
-use url::{Url};
-use crate::utils::{fetch_page_html};
-use reqwest::blocking::{Client};
+use crate::utils::fetch_page_html;
 use hashbrown::HashSet;
+use reqwest::blocking::Client;
+use scraper::{Html, Selector};
+use url::Url;
 
 /// Represent a page visited. This page contains HTML scraped with [scraper](https://crates.io/crates/scraper).
 #[derive(Debug, Clone)]
@@ -12,7 +12,7 @@ pub struct Page {
     /// HTML parsed with [scraper](https://crates.io/crates/scraper) lib. The html is not stored and only used to parse links.
     html: String,
     /// Base absolute url for page.
-    base: Url
+    base: Url,
 }
 
 /// CSS query selector to ignore all resources that are not valid web pages.
@@ -35,7 +35,7 @@ impl Page {
         Self {
             url: url.to_string(),
             html: html.to_string(),
-            base: Url::parse(&url).expect("Invalid page URL")
+            base: Url::parse(&url).expect("Invalid page URL"),
         }
     }
 
@@ -78,7 +78,8 @@ impl Page {
             let scheme = self.base.scheme();
             // . extension
             let tlds = if tld {
-                format!(r#"a[href^="{scheme}://{dname}"]{},"#, MEDIA_IGNORE_SELECTOR) // match everything that follows the base.
+                format!(r#"a[href^="{scheme}://{dname}"]{},"#, MEDIA_IGNORE_SELECTOR)
+            // match everything that follows the base.
             } else {
                 "".to_string()
             };
@@ -86,40 +87,31 @@ impl Page {
             let absolute_selector = &if subdomains {
                 format!(
                     r#"a[href^="{url}"]{},{tlds}a[href^="{scheme}"][href*=".{dname}."]{}"#,
-                    MEDIA_IGNORE_SELECTOR,
-                    MEDIA_IGNORE_SELECTOR,
+                    MEDIA_IGNORE_SELECTOR, MEDIA_IGNORE_SELECTOR,
                 )
             } else {
-                format!(
-                    r#"a[href^="{url}"]{}"#,
-                    MEDIA_IGNORE_SELECTOR,
-                )
+                format!(r#"a[href^="{url}"]{}"#, MEDIA_IGNORE_SELECTOR,)
             };
             let static_html_selector = &format!(
                 r#"{} {}, {absolute_selector} {}"#,
-                MEDIA_SELECTOR_RELATIVE,
-                MEDIA_SELECTOR_STATIC,
-                MEDIA_SELECTOR_STATIC
+                MEDIA_SELECTOR_RELATIVE, MEDIA_SELECTOR_STATIC, MEDIA_SELECTOR_STATIC
             );
             Selector::parse(&format!(
                 "{tlds}{},{absolute_selector},{static_html_selector}",
                 MEDIA_SELECTOR_RELATIVE
-            )).unwrap()
+            ))
+            .unwrap()
         } else {
-            let absolute_selector = format!(
-                r#"a[href^="{url}"]{}"#,
-                MEDIA_IGNORE_SELECTOR,
-            );
+            let absolute_selector = format!(r#"a[href^="{url}"]{}"#, MEDIA_IGNORE_SELECTOR,);
             let static_html_selector = &format!(
                 r#"{} {}, {absolute_selector} {}"#,
-                MEDIA_SELECTOR_RELATIVE,
-                MEDIA_SELECTOR_STATIC,
-                MEDIA_SELECTOR_STATIC
+                MEDIA_SELECTOR_RELATIVE, MEDIA_SELECTOR_STATIC, MEDIA_SELECTOR_STATIC
             );
             Selector::parse(&format!(
                 "{},{absolute_selector},{static_html_selector}",
                 MEDIA_SELECTOR_RELATIVE
-            )).unwrap()
+            ))
+            .unwrap()
         }
     }
 
@@ -132,24 +124,36 @@ impl Page {
         if subdomains {
             let base_domain = self.domain_name(&self.base);
 
-            anchors.filter_map(|a| {
-                let abs = self.abs_path(a.value().attr("href").unwrap_or_default()).to_string();
-                let url_domain = self.domain_name(&Url::parse(&abs).unwrap());
+            anchors
+                .filter_map(|a| {
+                    let abs = self
+                        .abs_path(a.value().attr("href").unwrap_or_default())
+                        .to_string();
+                    let url_domain = self.domain_name(&Url::parse(&abs).unwrap());
 
-                if base_domain == url_domain  {
-                    Some(abs)
-                } else {
-                    None
-                }
-            }).collect()
+                    if base_domain == url_domain {
+                        Some(abs)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
         } else {
-            anchors.map(|a| self.abs_path(a.value().attr("href").unwrap_or("")).to_string()).collect()
+            anchors
+                .map(|a| {
+                    self.abs_path(a.value().attr("href").unwrap_or(""))
+                        .to_string()
+                })
+                .collect()
         }
     }
 
     /// Convert a URL to its absolute path without any fragments or params.
     fn abs_path(&self, href: &str) -> Url {
-        let mut joined = self.base.join(href).unwrap_or(Url::parse(&self.url.to_string()).expect("Invalid page URL"));
+        let mut joined = self
+            .base
+            .join(href)
+            .unwrap_or(Url::parse(&self.url.to_string()).expect("Invalid page URL"));
 
         joined.set_fragment(None);
 
@@ -169,8 +173,7 @@ fn parse_links() {
     let links = page.links(false, false);
 
     assert!(
-        links
-            .contains(&"https://choosealicense.com/about/".to_string()),
+        links.contains(&"https://choosealicense.com/about/".to_string()),
         "Could not find {}. Theses URLs was found {:?}",
         page.url,
         &links

--- a/spider/src/utils.rs
+++ b/spider/src/utils.rs
@@ -1,6 +1,6 @@
-use reqwest::blocking::{Client};
+use log::{info, log_enabled, Level};
+use reqwest::blocking::Client;
 use reqwest::StatusCode;
-use log::{log_enabled, info, Level};
 
 /// Perform a network request to a resource extracting all content as text.
 pub fn fetch_page_html(url: &str, client: &Client) -> String {
@@ -11,7 +11,7 @@ pub fn fetch_page_html(url: &str, client: &Client) -> String {
             Ok(text) => body = text,
             Err(_) => {
                 log("- error fetching {}", &url);
-            },
+            }
         },
         Ok(_) => (),
         Err(_) => {

--- a/spider_cli/src/main.rs
+++ b/spider_cli/src/main.rs
@@ -1,6 +1,6 @@
-extern crate spider;
 extern crate env_logger;
 extern crate serde_json;
+extern crate spider;
 
 pub mod options;
 
@@ -22,10 +22,12 @@ fn main() {
     }
 
     let mut website: Website = Website::new(&cli.domain);
-    
+
     let delay = cli.delay.unwrap_or(website.configuration.delay);
     let concurrency = cli.concurrency.unwrap_or(website.configuration.concurrency);
-    let user_agent = cli.user_agent.unwrap_or(website.configuration.user_agent.to_string());
+    let user_agent = cli
+        .user_agent
+        .unwrap_or(website.configuration.user_agent.to_string());
     let blacklist_url = cli.blacklist_url.unwrap_or_default();
 
     website.configuration.respect_robots_txt = cli.respect_robots_txt;
@@ -53,12 +55,16 @@ fn main() {
 
             if *output_links {
                 let links: Vec<_> = website.get_links().iter().collect();
-                io::stdout().write_all(format!("{:?}", links).as_bytes()).unwrap();
+                io::stdout()
+                    .write_all(format!("{:?}", links).as_bytes())
+                    .unwrap();
             }
-
         }
-        Some(Commands::SCRAPE { output_html, output_links }) => {
-            use serde_json::{json};
+        Some(Commands::SCRAPE {
+            output_html,
+            output_links,
+        }) => {
+            use serde_json::json;
 
             website.scrape();
 
@@ -85,11 +91,10 @@ fn main() {
 
                 page_objects.push(page_json);
             }
-            
+
             let j = serde_json::to_string_pretty(&page_objects).unwrap();
 
             io::stdout().write_all(j.as_bytes()).unwrap();
-
         }
         None => {}
     }


### PR DESCRIPTION
* remove cli usage for spider bench test
* add local website test reducing latency flakes

-- notes
If the system does not need to perform any outside request `wget` performance drastically increases.